### PR TITLE
Make examples compile against 0.9.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalaVersion := "2.13.1"
 
 crossScalaVersions := Seq("2.12.10", "2.13.1")
 
-libraryDependencies += "com.raquo" %%% "laminar" % "0.8.0"
+libraryDependencies += "com.raquo" %%% "laminar" % "0.9.2"
 
 scalaJSUseMainModuleInitializer := true
 

--- a/src/main/scala/oldstuff/components/Toggle2.scala
+++ b/src/main/scala/oldstuff/components/Toggle2.scala
@@ -19,7 +19,7 @@ object Toggle2 {
     val rand = Random.nextInt(99)
 
     val checkbox = input(
-      id := "toggle" + rand,
+      idAttr := "toggle" + rand,
       className := "red",
       `type` := "checkbox",
       inContext(thisNode => onClick.preventDefault.mapTo(thisNode.ref.checked) --> checkedBus)

--- a/src/main/scala/oldstuff/todo/components/Toggle.scala
+++ b/src/main/scala/oldstuff/todo/components/Toggle.scala
@@ -24,7 +24,7 @@ object Toggle {
     val inputId = "toggle" + Random.nextInt(99)
 
     val checkbox = input(
-      id := inputId,
+      idAttr := inputId,
       className := "red",
       typ := "checkbox"
     )


### PR DESCRIPTION
Was using this as a starting point and noticed it wouldn't compile with 0.9.2 because of `id` in some oldstuff classes.