### PR TITLE
Web Component example: remove unnecessary dummy variables

### DIFF
--- a/src/main/scala/webcomponents/material/Button.scala
+++ b/src/main/scala/webcomponents/material/Button.scala
@@ -20,9 +20,7 @@ object Button {
   @js.native
   @JSImport("@material/mwc-button", JSImport.Default)
   object RawImport extends js.Object
-
-  // object-s are lazy so you need to actually use them in your code
-  private val _ = RawImport
+  RawImport // object-s are lazy so you need to actually use them in your code
 
   type Ref = dom.html.Element with RawElement
   type ModFunction = Button.type => Mod[ReactiveHtmlElement[Ref]]

--- a/src/main/scala/webcomponents/material/LinearProgressBar.scala
+++ b/src/main/scala/webcomponents/material/LinearProgressBar.scala
@@ -21,9 +21,7 @@ object LinearProgressBar {
   @js.native
   @JSImport("@material/mwc-linear-progress", JSImport.Default)
   object RawImport extends js.Object
-
-  // object-s are lazy so you need to actually use them in your code
-  private val _ = RawImport
+  RawImport // object-s are lazy so you need to actually use them in your code
 
   type Ref = dom.html.Element with RawElement
   type ModFunction = LinearProgressBar.type => Mod[ReactiveHtmlElement[Ref]]

--- a/src/main/scala/webcomponents/material/Slider.scala
+++ b/src/main/scala/webcomponents/material/Slider.scala
@@ -22,9 +22,7 @@ object Slider {
   @js.native
   @JSImport("@material/mwc-slider", JSImport.Default)
   object RawImport extends js.Object
-
-  // object-s are lazy so you need to actually use them in your code
-  private val _ = RawImport
+  RawImport // object-s are lazy so you need to actually use them in your code
 
   type Ref = dom.html.Element with RawElement
   type El = ReactiveHtmlElement[Ref]


### PR DESCRIPTION
Scalajs team replied to https://github.com/scala-js/scala-js/issues/4156 with a better way to do side-effect only native imports.

Updating examples to do it that way.
