### PR TITLE
Add tab bar example, and deser of MDCTabBar:activated

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ scalacOptions ++= Seq(
   "-feature",
   "-language:higherKinds",
   "-language:implicitConversions",
-  "-language:existentials",
+  "-language:existentials"
 )
 
 Compile / npmDependencies += "@material/mwc-button" -> "0.18.0"
@@ -33,6 +33,10 @@ Compile / npmDependencies += "@material/mwc-button" -> "0.18.0"
 Compile / npmDependencies += "@material/mwc-linear-progress" -> "0.18.0"
 
 Compile / npmDependencies += "@material/mwc-slider" -> "0.18.0"
+
+Compile / npmDependencies += "@material/mwc-tab" -> "0.18.0"
+
+Compile / npmDependencies += "@material/mwc-tab-bar" -> "0.18.0"
 
 scalaJSUseMainModuleInitializer := true
 

--- a/src/main/scala/webcomponents/WebComponents.scala
+++ b/src/main/scala/webcomponents/WebComponents.scala
@@ -12,21 +12,42 @@ object WebComponents {
     val actionVar = Var("Do the thing")
     val iconVar = Var("<>")
     val progressVar = Var(0d)
+    val tabVar = Var("")
 
     div(
       h1("Web Components"),
       p(
+        "The Tab Bar below is a ",
+        a(
+          href := "https://github.com/material-components/material-components-web-components/tree/master/packages/tab-bar",
+          "@material/mwc-tab-bar"
+        ),
+        " web component"
+      ),
+      p(
+        TabBar(
+          _ => Tab(_.label := "One"),
+          _ => Tab(_.label := "Two"),
+          _.activated.map(_.detail.index.toString) --> tabVar.writer
+        )
+      ),
+      child.text <-- tabVar.signal,
+      p(
         label("Button label: "),
         input(
           value <-- actionVar.signal,
-          inContext { thisNode => onInput.mapTo(thisNode.ref.value) --> actionVar.writer}
+          inContext { thisNode =>
+            onInput.mapTo(thisNode.ref.value) --> actionVar.writer
+          }
         )
       ),
       p(
         label("Button icon: "),
         input(
           value <-- iconVar.signal,
-          inContext { thisNode => onInput.mapTo(thisNode.ref.value) --> iconVar.writer}
+          inContext { thisNode =>
+            onInput.mapTo(thisNode.ref.value) --> iconVar.writer
+          }
         )
       ),
       p(
@@ -45,7 +66,7 @@ object WebComponents {
           _.styles.mdcThemePrimary := "#ff0000",
           _ => onClick --> (_ => dom.window.alert("Click")), // standard event
           _.onMouseOver --> (_ => println("MouseOver")), // "custom" event
-          _.slots.icon(span(child.text <-- iconVar.signal)),
+          _.slots.icon(span(child.text <-- iconVar.signal))
           //_ => onMountCallback(ctx => ctx.thisNode.ref.doThing()) // doThing is not implemented, just for reference
         )
       ),
@@ -60,7 +81,7 @@ object WebComponents {
         ),
         div(
           LinearProgressBar(
-            _.progress <-- progressVar.signal,
+            _.progress <-- progressVar.signal
           )
         ),
         p(
@@ -76,17 +97,21 @@ object WebComponents {
             _.pin := true,
             _.min := 0,
             _.max := 20,
-             _ => onMountCallback(ctx => {
-               js.timers.setTimeout(1) {
-                 // This component initializes its mdcFoundation asynchronously,
-                 // so we need a short delay before accessing .layout() on it.
-                 // To clarify, thisNode.ref already exists on mount, but the web component's
-                 // implementation of layout() depends on thisNode.ref.mdcFoundation, which is
-                 // populated asynchronously for some reason so it's not available on mount.
-                 dom.console.log(ctx.thisNode.ref.layout())
-               }
-             }),
-            slider => inContext { thisNode => slider.onInput.mapTo(thisNode.ref.value / 20) --> progressVar }
+            _ =>
+              onMountCallback(ctx => {
+                js.timers.setTimeout(1) {
+                  // This component initializes its mdcFoundation asynchronously,
+                  // so we need a short delay before accessing .layout() on it.
+                  // To clarify, thisNode.ref already exists on mount, but the web component's
+                  // implementation of layout() depends on thisNode.ref.mdcFoundation, which is
+                  // populated asynchronously for some reason so it's not available on mount.
+                  dom.console.log(ctx.thisNode.ref.layout())
+                }
+              }),
+            slider =>
+              inContext { thisNode =>
+                slider.onInput.mapTo(thisNode.ref.value / 20) --> progressVar
+              }
           )
         )
       )

--- a/src/main/scala/webcomponents/material/Tab.scala
+++ b/src/main/scala/webcomponents/material/Tab.scala
@@ -1,0 +1,39 @@
+package webcomponents.material
+
+import com.raquo.domtypes.generic.codecs.StringAsIsCodec
+import com.raquo.laminar.api.L._
+import com.raquo.laminar.nodes.ReactiveHtmlElement
+import org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object Tab {
+
+  @js.native
+  trait RawElement extends js.Object {
+    def activate(): Unit
+    def deactivate(): Unit
+  }
+
+  @js.native
+  @JSImport("@material/mwc-tab", JSImport.Default)
+  object RawImport extends js.Object
+  RawImport // object-s are lazy so you need to actually use them in your code
+
+  type Ref = dom.html.Element with RawElement
+  type El = ReactiveHtmlElement[Ref]
+  type ModFunction = Tab.type => Mod[El]
+
+  private val tag = customHtmlTag[Ref]("mwc-tab")
+
+  object slots {
+    def icon(el: HtmlElement): HtmlElement = el.amend(slot := "icon")
+  }
+
+  val label: Prop[String] = customProp("label", StringAsIsCodec)
+
+  def apply(mods: ModFunction*): El = {
+    tag(mods.map(_(Tab)): _*)
+  }
+}

--- a/src/main/scala/webcomponents/material/TabBar.scala
+++ b/src/main/scala/webcomponents/material/TabBar.scala
@@ -1,0 +1,41 @@
+package webcomponents.material
+
+import com.raquo.laminar.api.L._
+import com.raquo.laminar.nodes.ReactiveHtmlElement
+import org.scalajs.dom
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSImport
+
+object TabBar {
+
+  @js.native
+  trait RawElement extends js.Object {}
+
+  @js.native
+  @JSImport("@material/mwc-tab-bar", JSImport.Default)
+  object RawImport extends js.Object
+  RawImport // object-s are lazy so you need to actually use them in your code
+
+  type Ref = dom.html.Element with RawElement
+  type El = ReactiveHtmlElement[Ref]
+  type ModFunction = TabBar.type => Mod[El]
+
+  private val tag = customHtmlTag[Ref]("mwc-tab-bar")
+
+  val activated: EventProp[Activated] = customEventProp("MDCTabBar:activated")
+
+  @js.native
+  trait Activated extends dom.Event {
+    val detail: Index = js.native
+  }
+
+  @js.native
+  trait Index extends js.Object {
+    val index: Double = js.native
+  }
+
+  def apply(mods: ModFunction*): El = {
+    tag(mods.map(_(TabBar)): _*)
+  }
+}


### PR DESCRIPTION
Adds an example of consuming a material tab bar, and how to use `js.native` to deser `MDCTabBar:activated` event.

I can back out the formatting changes if you like.   Otherwise I was going to put adding a .scalafmt.conf to this project on my todo list and just formatting everything in one PR, and then adding a github action to enforce it.